### PR TITLE
LW-27086 - Upgraded psr/cache requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,6 @@
         "symfony/validator": "^5.4 || ^6.0",
         "webmozart/assert": "^1.9"
     },
-    "conflict": {
-        "psr/cache": ">=2.0.0"
-    },
     "autoload": {
         "psr-4": {
             "Lingoda\\BrazeBundle\\": "src/"


### PR DESCRIPTION
https://lingoda.atlassian.net/browse/LW-27086

We need to allow psr/cache ^2 | ^3 to upgrade symfony packages to 6.4