### PR TITLE
LW-28649 add subscription to Braze API

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,3 +19,7 @@ See documentation [new_alias.md](new_alias.md)
 ## Identify Users
 
 See documentation [identify_users.md](identify_users.md)
+
+## Set subscription group status
+
+See documentation [subscription_groups](subscription_groups.md)

--- a/docs/subscription_groups.md
+++ b/docs/subscription_groups.md
@@ -1,0 +1,34 @@
+# Subscription groups
+
+Subscription groups are used to subscribe user to some marketing channels, for example sms or whatsapp.
+Subscription groups ids could be seen in Braze, please ask CRM team for an ID of the group that you need.
+
+## update user subscription to some group
+
+```php
+
+use App\Braze\User\Object\UserExternalId;
+use App\Braze\User\Object\UserSubscriptionGroupId;
+use Lingoda\BrazeBundle\Api\BrazeApiInterface;
+use Lingoda\BrazeBundle\Api\Constants\SubscriptionType;
+
+
+
+/**
+ * @throws HttpException
+ */
+public function updatePhoneSubscriptions(User $user, SubscriptionType $status): void
+{
+
+	try {
+		$this->brazeApi->subscriptions()->setStatus(
+			new UserSubscriptionGroupId('subscription-group-id'),
+			$status,
+			UserExternalId::create($user),
+			$user->getPhoneNumber()
+		);
+	} catch (BrazeApiException $e) {
+		// handle exception
+	}
+}
+```

--- a/spec/Api/BrazeApiSpec.php
+++ b/spec/Api/BrazeApiSpec.php
@@ -7,14 +7,15 @@ namespace spec\Lingoda\BrazeBundle\Api;
 use Lingoda\BrazeBundle\Api\BrazeApi;
 use Lingoda\BrazeBundle\Api\Endpoint\Export;
 use Lingoda\BrazeBundle\Api\Endpoint\Messaging;
+use Lingoda\BrazeBundle\Api\Endpoint\SubscriptionGroups;
 use Lingoda\BrazeBundle\Api\Endpoint\Users;
 use PhpSpec\ObjectBehavior;
 
 class BrazeApiSpec extends ObjectBehavior
 {
-    function let(Users $users, Messaging $messaging, Export $export)
+    function let(Users $users, Messaging $messaging, Export $export, SubscriptionGroups $subscriptionGroups)
     {
-        $this->beConstructedWith($users, $messaging, $export);
+        $this->beConstructedWith($users, $messaging, $export, $subscriptionGroups);
     }
 
     function it_is_initializable()

--- a/src/Api/BrazeApi.php
+++ b/src/Api/BrazeApi.php
@@ -6,6 +6,8 @@ namespace Lingoda\BrazeBundle\Api;
 
 use Lingoda\BrazeBundle\Api\Endpoint\Export;
 use Lingoda\BrazeBundle\Api\Endpoint\Messaging;
+use Lingoda\BrazeBundle\Api\Endpoint\Subscription;
+use Lingoda\BrazeBundle\Api\Endpoint\SubscriptionGroups;
 use Lingoda\BrazeBundle\Api\Endpoint\Users;
 
 final class BrazeApi implements BrazeApiInterface
@@ -13,7 +15,8 @@ final class BrazeApi implements BrazeApiInterface
     public function __construct(
         private readonly Users $users,
         private readonly Messaging $messaging,
-        private readonly Export $export
+        private readonly Export $export,
+        private readonly SubscriptionGroups $subscriptionGroups,
     ) {
     }
 
@@ -30,5 +33,10 @@ final class BrazeApi implements BrazeApiInterface
     public function export(): Export
     {
         return $this->export;
+    }
+
+    public function subscriptionGroups(): SubscriptionGroups
+    {
+        return $this->subscriptionGroups;
     }
 }

--- a/src/Api/BrazeApi.php
+++ b/src/Api/BrazeApi.php
@@ -6,7 +6,6 @@ namespace Lingoda\BrazeBundle\Api;
 
 use Lingoda\BrazeBundle\Api\Endpoint\Export;
 use Lingoda\BrazeBundle\Api\Endpoint\Messaging;
-use Lingoda\BrazeBundle\Api\Endpoint\Subscription;
 use Lingoda\BrazeBundle\Api\Endpoint\SubscriptionGroups;
 use Lingoda\BrazeBundle\Api\Endpoint\Users;
 

--- a/src/Api/BrazeApiInterface.php
+++ b/src/Api/BrazeApiInterface.php
@@ -6,6 +6,7 @@ namespace Lingoda\BrazeBundle\Api;
 
 use Lingoda\BrazeBundle\Api\Endpoint\Export;
 use Lingoda\BrazeBundle\Api\Endpoint\Messaging;
+use Lingoda\BrazeBundle\Api\Endpoint\SubscriptionGroups;
 use Lingoda\BrazeBundle\Api\Endpoint\Users;
 
 interface BrazeApiInterface
@@ -15,4 +16,6 @@ interface BrazeApiInterface
     public function messaging(): Messaging;
 
     public function export(): Export;
+
+    public function subscriptionGroups(): SubscriptionGroups;
 }

--- a/src/Api/Endpoint/SubscriptionGroups.php
+++ b/src/Api/Endpoint/SubscriptionGroups.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Endpoint;
+
+use Lingoda\BrazeBundle\Api\BrazeClientInterface;
+use Lingoda\BrazeBundle\Api\Constants\SubscriptionType;
+use Lingoda\BrazeBundle\Api\Endpoint\Endpoint;
+use Lingoda\BrazeBundle\Api\Exception\HttpException;
+use Lingoda\BrazeBundle\Api\Object\ExternalId;
+use Lingoda\BrazeBundle\Api\Object\SubscriptionGroupId;
+use Lingoda\BrazeBundle\Api\Response\ApiResponseInterface;
+
+/**
+ * Subscription Groups endpoint
+ *
+ * @see https://www.braze.com/docs/api/endpoints/subscription_groups
+ */
+class SubscriptionGroups extends Endpoint
+{
+	private const BASE_ENDPOINT = 'subscriptions';
+
+	public function __construct(BrazeClientInterface $client)
+	{
+		parent::__construct($client);
+	}
+
+	/**
+	 * Use this endpoint to update user subscription status for a specific subscription group
+	 *
+	 * @see https://www.braze.com/docs/api/endpoints/subscription_groups/post_update_user_subscription_group_status
+	 *
+	 * @throws HttpException
+	 */
+	public function setStatus(
+		SubscriptionGroupId $subscriptionGroupId,
+		SubscriptionType $state,
+		ExternalId $externalId,
+		string $phone
+	): ApiResponseInterface
+	{
+		return $this->client->post(
+			self::BASE_ENDPOINT . '/status/set',
+			[
+				'attributes' => [
+					'external_id' => $externalId,
+					'phone' => $phone,
+					'subscription_group_id' => $subscriptionGroupId,
+					'subscription_state' => $state
+				],
+			]
+		);
+	}
+}

--- a/src/Api/Endpoint/SubscriptionGroups.php
+++ b/src/Api/Endpoint/SubscriptionGroups.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Lingoda\BrazeBundle\Api\Endpoint;
 
-use Lingoda\BrazeBundle\Api\BrazeClientInterface;
 use Lingoda\BrazeBundle\Api\Constants\SubscriptionType;
-use Lingoda\BrazeBundle\Api\Endpoint\Endpoint;
 use Lingoda\BrazeBundle\Api\Exception\HttpException;
 use Lingoda\BrazeBundle\Api\Object\ExternalId;
 use Lingoda\BrazeBundle\Api\Object\SubscriptionGroupId;
@@ -20,11 +18,6 @@ use Lingoda\BrazeBundle\Api\Response\ApiResponseInterface;
 class SubscriptionGroups extends Endpoint
 {
 	private const BASE_ENDPOINT = 'subscriptions';
-
-	public function __construct(BrazeClientInterface $client)
-	{
-		parent::__construct($client);
-	}
 
 	/**
 	 * Use this endpoint to update user subscription status for a specific subscription group

--- a/src/Api/Object/SubscriptionGroupId.php
+++ b/src/Api/Object/SubscriptionGroupId.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Lingoda\BrazeBundle\Api\Object;
+
+class SubscriptionGroupId extends Identifier
+{
+}

--- a/src/Resources/config/braze.xml
+++ b/src/Resources/config/braze.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="lingoda_braze.endpoint.users"/>
             <argument type="service" id="lingoda_braze.endpoint.messaging"/>
             <argument type="service" id="lingoda_braze.endpoint.export"/>
+            <argument type="service" id="lingoda_braze.endpoint.subscription_groups"/>
         </service>
         <service id="lingoda_braze.default_http_client" class="Lingoda\BrazeBundle\Api\BrazeHttpClientFactory">
             <factory class="Lingoda\BrazeBundle\Api\BrazeHttpClientFactory" method="create"/>
@@ -53,6 +54,9 @@
             <argument type="service" id="lingoda_braze.client"/>
         </service>
         <service id="lingoda_braze.endpoint.export" class="Lingoda\BrazeBundle\Api\Endpoint\Export">
+            <argument type="service" id="lingoda_braze.client"/>
+        </service>
+        <service id="lingoda_braze.endpoint.subscription_groups" class="Lingoda\BrazeBundle\Api\Endpoint\SubscriptionGroups">
             <argument type="service" id="lingoda_braze.client"/>
         </service>
 

--- a/tests/config/services.yaml
+++ b/tests/config/services.yaml
@@ -29,12 +29,18 @@ services:
         arguments:
             - '@test.mock.braze_client'
 
+    test.mock.braze_api_subscription_groups_endpoint:
+        class: Lingoda\BrazeBundle\Api\Endpoint\SubscriptionGroups
+        arguments:
+            - '@test.mock.braze_client'
+
     test.mock.braze_api:
         class: Lingoda\BrazeBundle\Api\BrazeApi
         arguments:
             - '@test.mock.braze_api_users_endpoint'
             - '@test.mock.braze_api_messaging_endpoint'
             - '@test.mock.braze_api_export_endpoint'
+            - '@test.mock.braze_api_subscription_groups_endpoint'
 
     test.mock.braze_client:
         class: Lingoda\BrazeBundle\Api\BrazeClient


### PR DESCRIPTION
Added SubscriptionGroup API usage, it's needed for phone/whatsapp subscriptions. 
https://www.braze.com/docs/api/endpoints/subscription_groups/post_update_user_subscription_group_status

Please let me know if should describe anything else here.