### PR TITLE
LW-32025 Added dtos for export of user data

### DIFF
--- a/spec/Api/Delta/UserAttributesDeltaResolverSpec.php
+++ b/spec/Api/Delta/UserAttributesDeltaResolverSpec.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Lingoda\BrazeBundle\Api\Delta;
+
+use Lingoda\BrazeBundle\Api\Delta\IdentifierResolver;
+use Lingoda\BrazeBundle\Api\Delta\StorageInterface;
+use Lingoda\BrazeBundle\Api\Delta\UserAttributesDeltaResolver;
+use Lingoda\BrazeBundle\Api\Object\ExternalId;
+use Lingoda\BrazeBundle\Api\Object\UserAttributes;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+class UserAttributesDeltaResolverSpec extends ObjectBehavior
+{
+    function let(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $this->beConstructedWith($store, $identifierResolver, $logger);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(UserAttributesDeltaResolver::class);
+    }
+
+    function it_stores_delta_attributes_when_no_previous_data_exists(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+            'email' => 'test@example.com',
+            'first_name' => 'John',
+        ]);
+
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn(null);
+
+        // Values are encoded as SHA256 hashes
+        $store->write('user-123', Argument::that(function ($options) {
+            return isset($options['email'])
+                && isset($options['first_name'])
+                && isset($options['external_id'])
+                && \count($options) === 3;
+        }))->shouldBeCalledOnce();
+
+        $logger->info(Argument::cetera())->shouldBeCalled();
+
+        $this->storeDeltaAttributes($userAttributes);
+    }
+
+    function it_merges_with_existing_data_when_storing_delta_attributes(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+            'email' => 'new@example.com',
+        ]);
+
+        $storedFirstNameHash = hash('sha256', 'John');
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn([
+            'first_name' => $storedFirstNameHash,
+            'email' => hash('sha256', 'old@example.com'),
+        ]);
+
+        // New email hash should overwrite old, first_name should be preserved
+        $store->write('user-123', Argument::that(function ($options) use ($storedFirstNameHash) {
+            return isset($options['email'])
+                && isset($options['first_name'])
+                && $options['first_name'] === $storedFirstNameHash
+                && isset($options['external_id']);
+        }))->shouldBeCalledOnce();
+
+        $logger->info(Argument::cetera())->shouldBeCalled();
+
+        $this->storeDeltaAttributes($userAttributes);
+    }
+
+    function it_new_values_overwrite_existing_when_storing(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+            'email' => 'new@example.com',
+        ]);
+
+        $storedFirstNameHash = hash('sha256', 'John');
+        $storedEmailHash = hash('sha256', 'old@example.com');
+        $newEmailHash = hash('sha256', 'new@example.com');
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn([
+            'first_name' => $storedFirstNameHash,
+            'email' => $storedEmailHash,
+        ]);
+
+        // New values overwrite stored values (array_merge behavior)
+        $store->write('user-123', Argument::that(function ($options) use ($newEmailHash, $storedFirstNameHash) {
+            return isset($options['email'])
+                && $options['email'] === $newEmailHash
+                && isset($options['first_name'])
+                && $options['first_name'] === $storedFirstNameHash;
+        }))->shouldBeCalledOnce();
+
+        $logger->info(Argument::cetera())->shouldBeCalled();
+
+        $this->storeDeltaAttributes($userAttributes);
+    }
+
+    function it_removes_delta_attributes_from_stored_data(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+        ]);
+
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => 'test@example.com',
+        ]);
+
+        $store->write('user-123', Argument::that(function ($options) {
+            return isset($options['last_name'])
+                && $options['last_name'] === 'Doe'
+                && !isset($options['first_name'])
+                && !isset($options['email']);
+        }))->shouldBeCalledOnce();
+
+        $logger->info(Argument::cetera())->shouldBeCalled();
+
+        $this->removeDeltaAttributes($userAttributes, ['first_name', 'email']);
+    }
+
+    function it_does_not_write_when_no_stored_data_exists_for_removal(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+        ]);
+
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn(null);
+
+        $store->write(Argument::cetera())->shouldNotBeCalled();
+        $logger->info(Argument::cetera())->shouldNotBeCalled();
+
+        $this->removeDeltaAttributes($userAttributes, ['first_name']);
+    }
+
+    function it_does_not_write_when_attributes_to_remove_is_empty(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+        ]);
+
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn([
+            'first_name' => 'John',
+        ]);
+
+        $store->write(Argument::cetera())->shouldNotBeCalled();
+        $logger->info(Argument::cetera())->shouldNotBeCalled();
+
+        $this->removeDeltaAttributes($userAttributes, []);
+    }
+
+    function it_ignores_non_existing_attributes_when_removing(
+        StorageInterface $store,
+        IdentifierResolver $identifierResolver,
+        LoggerInterface $logger
+    ) {
+        $externalId = new ExternalId('user-123');
+        $userAttributes = new UserAttributes([
+            'external_id' => $externalId,
+        ]);
+
+        $identifierResolver->resolve($userAttributes)->willReturn('user-123');
+        $store->read('user-123')->willReturn([
+            'first_name' => 'John',
+        ]);
+
+        $store->write('user-123', Argument::that(function ($options) {
+            return !isset($options['first_name'])
+                && empty($options);
+        }))->shouldBeCalledOnce();
+
+        $logger->info(Argument::cetera())->shouldBeCalled();
+
+        $this->removeDeltaAttributes($userAttributes, ['first_name', 'non_existing_attr']);
+    }
+}

--- a/spec/Api/Response/ApiUserExportResponseSpec.php
+++ b/spec/Api/Response/ApiUserExportResponseSpec.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace spec\Lingoda\BrazeBundle\Api\Response;
 
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\User;
 use Lingoda\BrazeBundle\Api\Response\ApiUserExportResponse;
 use PhpSpec\ObjectBehavior;
 
@@ -19,6 +20,7 @@ class ApiUserExportResponseSpec extends ObjectBehavior
         $this->getMessage()->shouldBeEqualTo('success');
 
         $this->getErrors()->shouldBe($errors);
-        $this->getUsers()->shouldBe($users);
+        $this->getUsersRaw()->shouldBe($users);
+        $this->getUsers()->shouldBeLike(array_map(User::fromArray(...), $users));
     }
 }

--- a/src/Api/Delta/UserAttributesDeltaResolver.php
+++ b/src/Api/Delta/UserAttributesDeltaResolver.php
@@ -93,6 +93,39 @@ class UserAttributesDeltaResolver
     }
 
     /**
+     * @param array<int, string> $attributesToRemove
+     */
+    public function removeDeltaAttributes(UserAttributes $userAttributes, array $attributesToRemove): void
+    {
+        $id = $this->identifierResolver->resolve($userAttributes);
+        Assert::notNull($id);
+
+        $storedOptions = $tempOptions = $this->getStoredOptions($userAttributes);
+        $removedOptions = [];
+
+        if (is_array($tempOptions) && !empty($attributesToRemove)) {
+            foreach ($attributesToRemove as $attribute) {
+                if (array_key_exists($attribute, $tempOptions)) {
+                    unset($tempOptions[$attribute]);
+                    $removedOptions[] = $attribute;
+                }
+            }
+
+            $this->deltaStore->write($id, $tempOptions);
+
+            $this->logger->info(
+                self::class . '::removeDeltaAttributes',
+                [
+                    'id' => $id,
+                    'storedOptions' => $storedOptions,
+                    'newOptions' => $tempOptions,
+                    'removedOptions' => $removedOptions,
+                ]
+            );
+        }
+    }
+
+    /**
      * @param array<string, mixed> $options
      * @param array<string, mixed> $storedEncodedOptions
      *

--- a/src/Api/Object/Export/SerializableExportObject.php
+++ b/src/Api/Object/Export/SerializableExportObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export;
+
+interface SerializableExportObject
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/Api/Object/Export/UserData/App.php
+++ b/src/Api/Object/Export/UserData/App.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class App implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $platform,
+        public readonly string $version,
+        public readonly int $sessions,
+        public readonly DateTimeImmutable $firstUsed,
+        public readonly DateTimeImmutable $lastUsed,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $firstUsed = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['first_used']);
+        $lastUsed = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['last_used']);
+
+        if ($firstUsed === false) {
+            throw new InvalidArgumentException('Invalid date format for first_used');
+        }
+        if ($lastUsed === false) {
+            throw new InvalidArgumentException('Invalid date format for last_used');
+        }
+
+        return new self(
+            name: $data['name'],
+            platform: $data['platform'],
+            version: $data['version'],
+            sessions: $data['sessions'],
+            firstUsed: $firstUsed,
+            lastUsed: $lastUsed,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'platform' => $this->platform,
+            'version' => $this->version,
+            'sessions' => $this->sessions,
+            'first_used' => $this->firstUsed->format(DateTimeInterface::RFC3339_EXTENDED),
+            'last_used' => $this->lastUsed->format(DateTimeInterface::RFC3339_EXTENDED),
+        ];
+    }
+}

--- a/src/Api/Object/Export/UserData/Campaign.php
+++ b/src/Api/Object/Export/UserData/Campaign.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class Campaign implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $apiCampaignId,
+        public readonly DateTimeImmutable $lastReceived,
+        public readonly CampaignEngagement $engaged,
+        public readonly bool $converted,
+        public readonly bool $inControl,
+        public readonly ?string $variationName = null,
+        public readonly ?string $variationApiId = null,
+        public readonly ?bool $multipleConverted = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $lastReceived = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::RFC3339_EXTENDED,
+            $data['last_received']
+        );
+
+        if ($lastReceived === false) {
+            throw new InvalidArgumentException('Invalid date format for last_received');
+        }
+
+        return new self(
+            name: $data['name'],
+            apiCampaignId: $data['api_campaign_id'],
+            lastReceived: $lastReceived,
+            engaged: CampaignEngagement::fromArray($data['engaged']),
+            converted: $data['converted'],
+            inControl: $data['in_control'],
+            variationName: $data['variation_name'] ?? null,
+            variationApiId: $data['variation_api_id'] ?? null,
+            multipleConverted: $data['multiple_converted'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'api_campaign_id' => $this->apiCampaignId,
+            'last_received' => $this->lastReceived->format(DateTimeInterface::RFC3339_EXTENDED),
+            'engaged' => $this->engaged->toArray(),
+            'converted' => $this->converted,
+            'in_control' => $this->inControl,
+            'variation_name' => $this->variationName,
+            'variation_api_id' => $this->variationApiId,
+            'multiple_converted' => $this->multipleConverted,
+        ], static fn ($value) => $value !== null);
+    }
+}

--- a/src/Api/Object/Export/UserData/CampaignEngagement.php
+++ b/src/Api/Object/Export/UserData/CampaignEngagement.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class CampaignEngagement implements SerializableExportObject
+{
+    public function __construct(
+        public readonly ?bool $openedEmail = null,
+        public readonly ?bool $openedPush = null,
+        public readonly ?bool $clickedEmail = null,
+        public readonly ?bool $clickedTriggeredInAppMessage = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            openedEmail: $data['opened_email'] ?? null,
+            openedPush: $data['opened_push'] ?? null,
+            clickedEmail: $data['clicked_email'] ?? null,
+            clickedTriggeredInAppMessage: $data['clicked_triggered_in_app_message'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'opened_email' => $this->openedEmail,
+            'opened_push' => $this->openedPush,
+            'clicked_email' => $this->clickedEmail,
+            'clicked_triggered_in_app_message' => $this->clickedTriggeredInAppMessage,
+        ], static fn ($value) => $value !== null);
+    }
+}

--- a/src/Api/Object/Export/UserData/Canvas.php
+++ b/src/Api/Object/Export/UserData/Canvas.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class Canvas implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $apiCanvasId,
+        public readonly DateTimeImmutable $lastReceivedMessage,
+        public readonly DateTimeImmutable $lastEntered,
+        public readonly DateTimeImmutable $lastExited,
+        public readonly bool $inControl,
+        public readonly ?string $variationName = null,
+        /** @var CanvasStep[]|null */
+        public readonly ?array $stepsReceived = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $lastReceivedMessage = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::RFC3339_EXTENDED,
+            $data['last_received_message']
+        );
+        $lastEntered = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['last_entered']);
+        $lastExited = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['last_exited']);
+
+        if ($lastReceivedMessage === false) {
+            throw new InvalidArgumentException('Invalid date format for last_received_message');
+        }
+        if ($lastEntered === false) {
+            throw new InvalidArgumentException('Invalid date format for last_entered');
+        }
+        if ($lastExited === false) {
+            throw new InvalidArgumentException('Invalid date format for last_exited');
+        }
+
+        return new self(
+            name: $data['name'],
+            apiCanvasId: $data['api_canvas_id'],
+            lastReceivedMessage: $lastReceivedMessage,
+            lastEntered: $lastEntered,
+            lastExited: $lastExited,
+            inControl: $data['in_control'],
+            variationName: $data['variation_name'] ?? null,
+            stepsReceived: isset($data['steps_received'])
+                ? array_map(CanvasStep::fromArray(...), $data['steps_received'])
+                : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'api_canvas_id' => $this->apiCanvasId,
+            'last_received_message' => $this->lastReceivedMessage->format(DateTimeInterface::RFC3339_EXTENDED),
+            'last_entered' => $this->lastEntered->format(DateTimeInterface::RFC3339_EXTENDED),
+            'last_exited' => $this->lastExited->format(DateTimeInterface::RFC3339_EXTENDED),
+            'in_control' => $this->inControl,
+            'variation_name' => $this->variationName,
+            'steps_received' => $this->stepsReceived !== null
+                ? array_map(static fn (CanvasStep $step) => $step->toArray(), $this->stepsReceived)
+                : null,
+        ], static fn ($value) => $value !== null);
+    }
+}

--- a/src/Api/Object/Export/UserData/CanvasStep.php
+++ b/src/Api/Object/Export/UserData/CanvasStep.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class CanvasStep implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $apiCanvasStepId,
+        public readonly DateTimeImmutable $lastReceived,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $lastReceived = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::RFC3339_EXTENDED,
+            $data['last_received']
+        );
+
+        if ($lastReceived === false) {
+            throw new InvalidArgumentException('Invalid date format for last_received');
+        }
+
+        return new self(
+            name: $data['name'],
+            apiCanvasStepId: $data['api_canvas_step_id'],
+            lastReceived: $lastReceived,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'api_canvas_step_id' => $this->apiCanvasStepId,
+            'last_received' => $this->lastReceived->format(DateTimeInterface::RFC3339_EXTENDED),
+        ];
+    }
+}

--- a/src/Api/Object/Export/UserData/Card.php
+++ b/src/Api/Object/Export/UserData/Card.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class Card implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/src/Api/Object/Export/UserData/CustomEvent.php
+++ b/src/Api/Object/Export/UserData/CustomEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class CustomEvent implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly DateTimeImmutable $first,
+        public readonly DateTimeImmutable $last,
+        public readonly int $count,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $first = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['first']);
+        $last = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['last']);
+
+        if ($first === false) {
+            throw new InvalidArgumentException('Invalid date format for first');
+        }
+        if ($last === false) {
+            throw new InvalidArgumentException('Invalid date format for last');
+        }
+
+        return new self(
+            name: $data['name'],
+            first: $first,
+            last: $last,
+            count: $data['count'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'first' => $this->first->format(DateTimeInterface::RFC3339_EXTENDED),
+            'last' => $this->last->format(DateTimeInterface::RFC3339_EXTENDED),
+            'count' => $this->count,
+        ];
+    }
+}

--- a/src/Api/Object/Export/UserData/Device.php
+++ b/src/Api/Object/Export/UserData/Device.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class Device implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $model,
+        public readonly string $os,
+        public readonly string $deviceId,
+        public readonly bool $adTrackingEnabled,
+        public readonly ?string $carrier = null,
+        public readonly ?string $idfv = null,
+        public readonly ?string $idfa = null,
+        public readonly ?string $googleAdId = null,
+        public readonly ?string $rokuAdId = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            model: $data['model'],
+            os: $data['os'],
+            deviceId: $data['device_id'],
+            adTrackingEnabled: $data['ad_tracking_enabled'],
+            carrier: $data['carrier'] ?? null,
+            idfv: $data['idfv'] ?? null,
+            idfa: $data['idfa'] ?? null,
+            googleAdId: $data['google_ad_id'] ?? null,
+            rokuAdId: $data['roku_ad_id'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'model' => $this->model,
+            'os' => $this->os,
+            'device_id' => $this->deviceId,
+            'ad_tracking_enabled' => $this->adTrackingEnabled,
+            'carrier' => $this->carrier,
+            'idfv' => $this->idfv,
+            'idfa' => $this->idfa,
+            'google_ad_id' => $this->googleAdId,
+            'roku_ad_id' => $this->rokuAdId,
+        ], static fn ($value) => $value !== null);
+    }
+}

--- a/src/Api/Object/Export/UserData/Gender.php
+++ b/src/Api/Object/Export/UserData/Gender.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+enum Gender: string
+{
+    case Male = 'M';
+    case Female = 'F';
+    case Other = 'O';
+    case NotApplicable = 'N';
+    case PreferNotToSay = 'P';
+    case Unknown = 'nil';
+}

--- a/src/Api/Object/Export/UserData/Purchase.php
+++ b/src/Api/Object/Export/UserData/Purchase.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class Purchase implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly DateTimeImmutable $first,
+        public readonly DateTimeImmutable $last,
+        public readonly int $count,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $first = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['first']);
+        $last = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['last']);
+
+        if ($first === false) {
+            throw new InvalidArgumentException('Invalid date format for first');
+        }
+        if ($last === false) {
+            throw new InvalidArgumentException('Invalid date format for last');
+        }
+
+        return new self(
+            name: $data['name'],
+            first: $first,
+            last: $last,
+            count: $data['count'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'first' => $this->first->format(DateTimeInterface::RFC3339_EXTENDED),
+            'last' => $this->last->format(DateTimeInterface::RFC3339_EXTENDED),
+            'count' => $this->count,
+        ];
+    }
+}

--- a/src/Api/Object/Export/UserData/PushToken.php
+++ b/src/Api/Object/Export/UserData/PushToken.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+
+final class PushToken implements SerializableExportObject
+{
+    public function __construct(
+        public readonly string $app,
+        public readonly string $platform,
+        public readonly string $token,
+        public readonly string $deviceId,
+        public readonly bool $notificationsEnabled,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            app: $data['app'],
+            platform: $data['platform'],
+            token: $data['token'],
+            deviceId: $data['device_id'],
+            notificationsEnabled: $data['notifications_enabled'],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'app' => $this->app,
+            'platform' => $this->platform,
+            'token' => $this->token,
+            'device_id' => $this->deviceId,
+            'notifications_enabled' => $this->notificationsEnabled,
+        ];
+    }
+}

--- a/src/Api/Object/Export/UserData/User.php
+++ b/src/Api/Object/Export/UserData/User.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\SerializableExportObject;
+use Lingoda\BrazeBundle\Api\Object\UserAlias;
+
+/**
+ * Exported user data from Braze API.
+ *
+ * @see https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier
+ * @see https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment
+ * @see https://www.braze.com/docs/api/endpoints/export/user_data/post_users_global_control_group
+ */
+final class User implements SerializableExportObject
+{
+    private const DATE_FORMAT_CREATED_AT = 'Y-m-d H:i:s.v e';
+    private const DATE_FORMAT_DOB = 'Y-m-d';
+
+    public function __construct(
+        public readonly ?DateTimeImmutable $createdAt = null,
+        public readonly ?string $externalId = null,
+        public readonly ?string $brazeId = null,
+        /** @var UserAlias[]|null */
+        public readonly ?array $userAliases = null,
+        public readonly ?int $randomBucket = null,
+        public readonly ?string $firstName = null,
+        public readonly ?string $lastName = null,
+        public readonly ?string $email = null,
+        public readonly ?DateTimeImmutable $dob = null,
+        public readonly ?string $homeCity = null,
+        public readonly ?string $country = null,
+        public readonly ?string $phone = null,
+        public readonly ?string $language = null,
+        public readonly ?string $timeZone = null,
+        public readonly ?Gender $gender = null,
+        /** @var float[]|null [longitude, latitude] */
+        public readonly ?array $lastCoordinates = null,
+        public readonly ?string $pushSubscribe = null,
+        public readonly ?DateTimeImmutable $pushOptedInAt = null,
+        public readonly ?string $emailSubscribe = null,
+        public readonly ?float $totalRevenue = null,
+        public readonly ?string $attributedCampaign = null,
+        public readonly ?string $attributedSource = null,
+        public readonly ?string $attributedAdgroup = null,
+        public readonly ?string $attributedAd = null,
+        /** @var array<string, mixed>|null */
+        public readonly ?array $customAttributes = null,
+        /** @var CustomEvent[]|null */
+        public readonly ?array $customEvents = null,
+        /** @var Purchase[]|null */
+        public readonly ?array $purchases = null,
+        /** @var Device[]|null */
+        public readonly ?array $devices = null,
+        /** @var PushToken[]|null */
+        public readonly ?array $pushTokens = null,
+        /** @var App[]|null */
+        public readonly ?array $apps = null,
+        /** @var Campaign[]|null */
+        public readonly ?array $campaignsReceived = null,
+        /** @var Canvas[]|null */
+        public readonly ?array $canvasesReceived = null,
+        /** @var Card[]|null */
+        public readonly ?array $cardsClicked = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $createdAt = isset($data['created_at'])
+            ? DateTimeImmutable::createFromFormat(self::DATE_FORMAT_CREATED_AT, $data['created_at'])
+            : null;
+        $dob = isset($data['dob'])
+            ? DateTimeImmutable::createFromFormat(self::DATE_FORMAT_DOB, $data['dob'])
+            : null;
+        $pushOptedInAt = isset($data['push_opted_in_at'])
+            ? DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339_EXTENDED, $data['push_opted_in_at'])
+            : null;
+
+        if ($createdAt === false) {
+            throw new InvalidArgumentException('Invalid date format for created_at');
+        }
+        if ($dob === false) {
+            throw new InvalidArgumentException('Invalid date format for dob');
+        }
+        if ($pushOptedInAt === false) {
+            throw new InvalidArgumentException('Invalid date format for push_opted_in_at');
+        }
+
+        return new self(
+            createdAt: $createdAt,
+            externalId: $data['external_id'] ?? null,
+            brazeId: $data['braze_id'] ?? null,
+            userAliases: isset($data['user_aliases']) ? array_map(
+                static fn (array $alias) => new UserAlias($alias['alias_name'], $alias['alias_label']),
+                $data['user_aliases']
+            ) : null,
+            randomBucket: $data['random_bucket'] ?? null,
+            firstName: $data['first_name'] ?? null,
+            lastName: $data['last_name'] ?? null,
+            email: $data['email'] ?? null,
+            dob: $dob,
+            homeCity: $data['home_city'] ?? null,
+            country: $data['country'] ?? null,
+            phone: $data['phone'] ?? null,
+            language: $data['language'] ?? null,
+            timeZone: $data['time_zone'] ?? null,
+            gender: isset($data['gender']) ? Gender::tryFrom($data['gender']) : null,
+            lastCoordinates: $data['last_coordinates'] ?? null,
+            pushSubscribe: $data['push_subscribe'] ?? null,
+            pushOptedInAt: $pushOptedInAt,
+            emailSubscribe: $data['email_subscribe'] ?? null,
+            totalRevenue: $data['total_revenue'] ?? null,
+            attributedCampaign: $data['attributed_campaign'] ?? null,
+            attributedSource: $data['attributed_source'] ?? null,
+            attributedAdgroup: $data['attributed_adgroup'] ?? null,
+            attributedAd: $data['attributed_ad'] ?? null,
+            customAttributes: $data['custom_attributes'] ?? null,
+            customEvents: isset($data['custom_events'])
+                ? array_map(CustomEvent::fromArray(...), $data['custom_events'])
+                : null,
+            purchases: isset($data['purchases'])
+                ? array_map(Purchase::fromArray(...), $data['purchases'])
+                : null,
+            devices: isset($data['devices'])
+                ? array_map(Device::fromArray(...), $data['devices'])
+                : null,
+            pushTokens: isset($data['push_tokens'])
+                ? array_map(PushToken::fromArray(...), $data['push_tokens'])
+                : null,
+            apps: isset($data['apps'])
+                ? array_map(App::fromArray(...), $data['apps'])
+                : null,
+            campaignsReceived: isset($data['campaigns_received'])
+                ? array_map(Campaign::fromArray(...), $data['campaigns_received'])
+                : null,
+            canvasesReceived: isset($data['canvases_received'])
+                ? array_map(Canvas::fromArray(...), $data['canvases_received'])
+                : null,
+            cardsClicked: isset($data['cards_clicked'])
+                ? array_map(Card::fromArray(...), $data['cards_clicked'])
+                : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'created_at' => $this->createdAt?->format(self::DATE_FORMAT_CREATED_AT),
+            'external_id' => $this->externalId,
+            'braze_id' => $this->brazeId,
+            'user_aliases' => $this->userAliases !== null
+                ? array_map(static fn (UserAlias $alias) => $alias->getValue(), $this->userAliases)
+                : null,
+            'random_bucket' => $this->randomBucket,
+            'first_name' => $this->firstName,
+            'last_name' => $this->lastName,
+            'email' => $this->email,
+            'dob' => $this->dob?->format(self::DATE_FORMAT_DOB),
+            'home_city' => $this->homeCity,
+            'country' => $this->country,
+            'phone' => $this->phone,
+            'language' => $this->language,
+            'time_zone' => $this->timeZone,
+            'gender' => $this->gender?->value,
+            'last_coordinates' => $this->lastCoordinates,
+            'push_subscribe' => $this->pushSubscribe,
+            'push_opted_in_at' => $this->pushOptedInAt?->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'email_subscribe' => $this->emailSubscribe,
+            'total_revenue' => $this->totalRevenue,
+            'attributed_campaign' => $this->attributedCampaign,
+            'attributed_source' => $this->attributedSource,
+            'attributed_adgroup' => $this->attributedAdgroup,
+            'attributed_ad' => $this->attributedAd,
+            'custom_attributes' => $this->customAttributes,
+            'custom_events' => $this->customEvents !== null
+                ? array_map(static fn (CustomEvent $e) => $e->toArray(), $this->customEvents)
+                : null,
+            'purchases' => $this->purchases !== null
+                ? array_map(static fn (Purchase $p) => $p->toArray(), $this->purchases)
+                : null,
+            'devices' => $this->devices !== null
+                ? array_map(static fn (Device $d) => $d->toArray(), $this->devices)
+                : null,
+            'push_tokens' => $this->pushTokens !== null
+                ? array_map(static fn (PushToken $t) => $t->toArray(), $this->pushTokens)
+                : null,
+            'apps' => $this->apps !== null
+                ? array_map(static fn (App $a) => $a->toArray(), $this->apps)
+                : null,
+            'campaigns_received' => $this->campaignsReceived !== null
+                ? array_map(static fn (Campaign $c) => $c->toArray(), $this->campaignsReceived)
+                : null,
+            'canvases_received' => $this->canvasesReceived !== null
+                ? array_map(static fn (Canvas $c) => $c->toArray(), $this->canvasesReceived)
+                : null,
+            'cards_clicked' => $this->cardsClicked !== null
+                ? array_map(static fn (Card $c) => $c->toArray(), $this->cardsClicked)
+                : null,
+        ], static fn ($value) => $value !== null);
+    }
+}

--- a/src/Api/Object/Export/UserData/User.php
+++ b/src/Api/Object/Export/UserData/User.php
@@ -18,6 +18,39 @@ use Lingoda\BrazeBundle\Api\Object\UserAlias;
  */
 final class User implements SerializableExportObject
 {
+    public const FIELD_CREATED_AT = 'created_at';
+    public const FIELD_EXTERNAL_ID = 'external_id';
+    public const FIELD_BRAZE_ID = 'braze_id';
+    public const FIELD_USER_ALIASES = 'user_aliases';
+    public const FIELD_RANDOM_BUCKET = 'random_bucket';
+    public const FIELD_FIRST_NAME = 'first_name';
+    public const FIELD_LAST_NAME = 'last_name';
+    public const FIELD_EMAIL = 'email';
+    public const FIELD_DOB = 'dob';
+    public const FIELD_HOME_CITY = 'home_city';
+    public const FIELD_COUNTRY = 'country';
+    public const FIELD_PHONE = 'phone';
+    public const FIELD_LANGUAGE = 'language';
+    public const FIELD_TIME_ZONE = 'time_zone';
+    public const FIELD_GENDER = 'gender';
+    public const FIELD_LAST_COORDINATES = 'last_coordinates';
+    public const FIELD_PUSH_SUBSCRIBE = 'push_subscribe';
+    public const FIELD_PUSH_OPTED_IN_AT = 'push_opted_in_at';
+    public const FIELD_EMAIL_SUBSCRIBE = 'email_subscribe';
+    public const FIELD_TOTAL_REVENUE = 'total_revenue';
+    public const FIELD_ATTRIBUTED_CAMPAIGN = 'attributed_campaign';
+    public const FIELD_ATTRIBUTED_SOURCE = 'attributed_source';
+    public const FIELD_ATTRIBUTED_ADGROUP = 'attributed_adgroup';
+    public const FIELD_ATTRIBUTED_AD = 'attributed_ad';
+    public const FIELD_CUSTOM_ATTRIBUTES = 'custom_attributes';
+    public const FIELD_CUSTOM_EVENTS = 'custom_events';
+    public const FIELD_PURCHASES = 'purchases';
+    public const FIELD_DEVICES = 'devices';
+    public const FIELD_PUSH_TOKENS = 'push_tokens';
+    public const FIELD_APPS = 'apps';
+    public const FIELD_CAMPAIGNS_RECEIVED = 'campaigns_received';
+    public const FIELD_CANVASES_RECEIVED = 'canvases_received';
+    public const FIELD_CARDS_CLICKED = 'cards_clicked';
     private const DATE_FORMAT_CREATED_AT = 'Y-m-d H:i:s.v e';
     private const DATE_FORMAT_DOB = 'Y-m-d';
 
@@ -74,78 +107,81 @@ final class User implements SerializableExportObject
      */
     public static function fromArray(array $data): self
     {
-        $createdAt = isset($data['created_at'])
-            ? DateTimeImmutable::createFromFormat(self::DATE_FORMAT_CREATED_AT, $data['created_at'])
+        $createdAt = isset($data[self::FIELD_CREATED_AT])
+            ? DateTimeImmutable::createFromFormat(self::DATE_FORMAT_CREATED_AT, $data[self::FIELD_CREATED_AT])
             : null;
-        $dob = isset($data['dob'])
-            ? DateTimeImmutable::createFromFormat(self::DATE_FORMAT_DOB, $data['dob'])
+        $dob = isset($data[self::FIELD_DOB])
+            ? DateTimeImmutable::createFromFormat(self::DATE_FORMAT_DOB, $data[self::FIELD_DOB])
             : null;
-        $pushOptedInAt = isset($data['push_opted_in_at'])
-            ? DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339_EXTENDED, $data['push_opted_in_at'])
+        $pushOptedInAt = isset($data[self::FIELD_PUSH_OPTED_IN_AT])
+            ? DateTimeImmutable::createFromFormat(
+                \DateTimeInterface::RFC3339_EXTENDED,
+                $data[self::FIELD_PUSH_OPTED_IN_AT]
+            )
             : null;
 
         if ($createdAt === false) {
-            throw new InvalidArgumentException('Invalid date format for created_at');
+            throw new InvalidArgumentException('Invalid date format for ' . self::FIELD_CREATED_AT);
         }
         if ($dob === false) {
-            throw new InvalidArgumentException('Invalid date format for dob');
+            throw new InvalidArgumentException('Invalid date format for ' . self::FIELD_DOB);
         }
         if ($pushOptedInAt === false) {
-            throw new InvalidArgumentException('Invalid date format for push_opted_in_at');
+            throw new InvalidArgumentException('Invalid date format for ' . self::FIELD_PUSH_OPTED_IN_AT);
         }
 
         return new self(
             createdAt: $createdAt,
-            externalId: $data['external_id'] ?? null,
-            brazeId: $data['braze_id'] ?? null,
-            userAliases: isset($data['user_aliases']) ? array_map(
+            externalId: $data[self::FIELD_EXTERNAL_ID] ?? null,
+            brazeId: $data[self::FIELD_BRAZE_ID] ?? null,
+            userAliases: isset($data[self::FIELD_USER_ALIASES]) ? array_map(
                 static fn (array $alias) => new UserAlias($alias['alias_name'], $alias['alias_label']),
-                $data['user_aliases']
+                $data[self::FIELD_USER_ALIASES]
             ) : null,
-            randomBucket: $data['random_bucket'] ?? null,
-            firstName: $data['first_name'] ?? null,
-            lastName: $data['last_name'] ?? null,
-            email: $data['email'] ?? null,
+            randomBucket: $data[self::FIELD_RANDOM_BUCKET] ?? null,
+            firstName: $data[self::FIELD_FIRST_NAME] ?? null,
+            lastName: $data[self::FIELD_LAST_NAME] ?? null,
+            email: $data[self::FIELD_EMAIL] ?? null,
             dob: $dob,
-            homeCity: $data['home_city'] ?? null,
-            country: $data['country'] ?? null,
-            phone: $data['phone'] ?? null,
-            language: $data['language'] ?? null,
-            timeZone: $data['time_zone'] ?? null,
-            gender: isset($data['gender']) ? Gender::tryFrom($data['gender']) : null,
-            lastCoordinates: $data['last_coordinates'] ?? null,
-            pushSubscribe: $data['push_subscribe'] ?? null,
+            homeCity: $data[self::FIELD_HOME_CITY] ?? null,
+            country: $data[self::FIELD_COUNTRY] ?? null,
+            phone: $data[self::FIELD_PHONE] ?? null,
+            language: $data[self::FIELD_LANGUAGE] ?? null,
+            timeZone: $data[self::FIELD_TIME_ZONE] ?? null,
+            gender: isset($data[self::FIELD_GENDER]) ? Gender::tryFrom($data[self::FIELD_GENDER]) : null,
+            lastCoordinates: $data[self::FIELD_LAST_COORDINATES] ?? null,
+            pushSubscribe: $data[self::FIELD_PUSH_SUBSCRIBE] ?? null,
             pushOptedInAt: $pushOptedInAt,
-            emailSubscribe: $data['email_subscribe'] ?? null,
-            totalRevenue: $data['total_revenue'] ?? null,
-            attributedCampaign: $data['attributed_campaign'] ?? null,
-            attributedSource: $data['attributed_source'] ?? null,
-            attributedAdgroup: $data['attributed_adgroup'] ?? null,
-            attributedAd: $data['attributed_ad'] ?? null,
-            customAttributes: $data['custom_attributes'] ?? null,
-            customEvents: isset($data['custom_events'])
-                ? array_map(CustomEvent::fromArray(...), $data['custom_events'])
+            emailSubscribe: $data[self::FIELD_EMAIL_SUBSCRIBE] ?? null,
+            totalRevenue: $data[self::FIELD_TOTAL_REVENUE] ?? null,
+            attributedCampaign: $data[self::FIELD_ATTRIBUTED_CAMPAIGN] ?? null,
+            attributedSource: $data[self::FIELD_ATTRIBUTED_SOURCE] ?? null,
+            attributedAdgroup: $data[self::FIELD_ATTRIBUTED_ADGROUP] ?? null,
+            attributedAd: $data[self::FIELD_ATTRIBUTED_AD] ?? null,
+            customAttributes: $data[self::FIELD_CUSTOM_ATTRIBUTES] ?? null,
+            customEvents: isset($data[self::FIELD_CUSTOM_EVENTS])
+                ? array_map(CustomEvent::fromArray(...), $data[self::FIELD_CUSTOM_EVENTS])
                 : null,
-            purchases: isset($data['purchases'])
-                ? array_map(Purchase::fromArray(...), $data['purchases'])
+            purchases: isset($data[self::FIELD_PURCHASES])
+                ? array_map(Purchase::fromArray(...), $data[self::FIELD_PURCHASES])
                 : null,
-            devices: isset($data['devices'])
-                ? array_map(Device::fromArray(...), $data['devices'])
+            devices: isset($data[self::FIELD_DEVICES])
+                ? array_map(Device::fromArray(...), $data[self::FIELD_DEVICES])
                 : null,
-            pushTokens: isset($data['push_tokens'])
-                ? array_map(PushToken::fromArray(...), $data['push_tokens'])
+            pushTokens: isset($data[self::FIELD_PUSH_TOKENS])
+                ? array_map(PushToken::fromArray(...), $data[self::FIELD_PUSH_TOKENS])
                 : null,
-            apps: isset($data['apps'])
-                ? array_map(App::fromArray(...), $data['apps'])
+            apps: isset($data[self::FIELD_APPS])
+                ? array_map(App::fromArray(...), $data[self::FIELD_APPS])
                 : null,
-            campaignsReceived: isset($data['campaigns_received'])
-                ? array_map(Campaign::fromArray(...), $data['campaigns_received'])
+            campaignsReceived: isset($data[self::FIELD_CAMPAIGNS_RECEIVED])
+                ? array_map(Campaign::fromArray(...), $data[self::FIELD_CAMPAIGNS_RECEIVED])
                 : null,
-            canvasesReceived: isset($data['canvases_received'])
-                ? array_map(Canvas::fromArray(...), $data['canvases_received'])
+            canvasesReceived: isset($data[self::FIELD_CANVASES_RECEIVED])
+                ? array_map(Canvas::fromArray(...), $data[self::FIELD_CANVASES_RECEIVED])
                 : null,
-            cardsClicked: isset($data['cards_clicked'])
-                ? array_map(Card::fromArray(...), $data['cards_clicked'])
+            cardsClicked: isset($data[self::FIELD_CARDS_CLICKED])
+                ? array_map(Card::fromArray(...), $data[self::FIELD_CARDS_CLICKED])
                 : null,
         );
     }
@@ -153,55 +189,55 @@ final class User implements SerializableExportObject
     public function toArray(): array
     {
         return array_filter([
-            'created_at' => $this->createdAt?->format(self::DATE_FORMAT_CREATED_AT),
-            'external_id' => $this->externalId,
-            'braze_id' => $this->brazeId,
-            'user_aliases' => $this->userAliases !== null
+            self::FIELD_CREATED_AT => $this->createdAt?->format(self::DATE_FORMAT_CREATED_AT),
+            self::FIELD_EXTERNAL_ID => $this->externalId,
+            self::FIELD_BRAZE_ID => $this->brazeId,
+            self::FIELD_USER_ALIASES => $this->userAliases !== null
                 ? array_map(static fn (UserAlias $alias) => $alias->getValue(), $this->userAliases)
                 : null,
-            'random_bucket' => $this->randomBucket,
-            'first_name' => $this->firstName,
-            'last_name' => $this->lastName,
-            'email' => $this->email,
-            'dob' => $this->dob?->format(self::DATE_FORMAT_DOB),
-            'home_city' => $this->homeCity,
-            'country' => $this->country,
-            'phone' => $this->phone,
-            'language' => $this->language,
-            'time_zone' => $this->timeZone,
-            'gender' => $this->gender?->value,
-            'last_coordinates' => $this->lastCoordinates,
-            'push_subscribe' => $this->pushSubscribe,
-            'push_opted_in_at' => $this->pushOptedInAt?->format(\DateTimeInterface::RFC3339_EXTENDED),
-            'email_subscribe' => $this->emailSubscribe,
-            'total_revenue' => $this->totalRevenue,
-            'attributed_campaign' => $this->attributedCampaign,
-            'attributed_source' => $this->attributedSource,
-            'attributed_adgroup' => $this->attributedAdgroup,
-            'attributed_ad' => $this->attributedAd,
-            'custom_attributes' => $this->customAttributes,
-            'custom_events' => $this->customEvents !== null
+            self::FIELD_RANDOM_BUCKET => $this->randomBucket,
+            self::FIELD_FIRST_NAME => $this->firstName,
+            self::FIELD_LAST_NAME => $this->lastName,
+            self::FIELD_EMAIL => $this->email,
+            self::FIELD_DOB => $this->dob?->format(self::DATE_FORMAT_DOB),
+            self::FIELD_HOME_CITY => $this->homeCity,
+            self::FIELD_COUNTRY => $this->country,
+            self::FIELD_PHONE => $this->phone,
+            self::FIELD_LANGUAGE => $this->language,
+            self::FIELD_TIME_ZONE => $this->timeZone,
+            self::FIELD_GENDER => $this->gender?->value,
+            self::FIELD_LAST_COORDINATES => $this->lastCoordinates,
+            self::FIELD_PUSH_SUBSCRIBE => $this->pushSubscribe,
+            self::FIELD_PUSH_OPTED_IN_AT => $this->pushOptedInAt?->format(\DateTimeInterface::RFC3339_EXTENDED),
+            self::FIELD_EMAIL_SUBSCRIBE => $this->emailSubscribe,
+            self::FIELD_TOTAL_REVENUE => $this->totalRevenue,
+            self::FIELD_ATTRIBUTED_CAMPAIGN => $this->attributedCampaign,
+            self::FIELD_ATTRIBUTED_SOURCE => $this->attributedSource,
+            self::FIELD_ATTRIBUTED_ADGROUP => $this->attributedAdgroup,
+            self::FIELD_ATTRIBUTED_AD => $this->attributedAd,
+            self::FIELD_CUSTOM_ATTRIBUTES => $this->customAttributes,
+            self::FIELD_CUSTOM_EVENTS => $this->customEvents !== null
                 ? array_map(static fn (CustomEvent $e) => $e->toArray(), $this->customEvents)
                 : null,
-            'purchases' => $this->purchases !== null
+            self::FIELD_PURCHASES => $this->purchases !== null
                 ? array_map(static fn (Purchase $p) => $p->toArray(), $this->purchases)
                 : null,
-            'devices' => $this->devices !== null
+            self::FIELD_DEVICES => $this->devices !== null
                 ? array_map(static fn (Device $d) => $d->toArray(), $this->devices)
                 : null,
-            'push_tokens' => $this->pushTokens !== null
+            self::FIELD_PUSH_TOKENS => $this->pushTokens !== null
                 ? array_map(static fn (PushToken $t) => $t->toArray(), $this->pushTokens)
                 : null,
-            'apps' => $this->apps !== null
+            self::FIELD_APPS => $this->apps !== null
                 ? array_map(static fn (App $a) => $a->toArray(), $this->apps)
                 : null,
-            'campaigns_received' => $this->campaignsReceived !== null
+            self::FIELD_CAMPAIGNS_RECEIVED => $this->campaignsReceived !== null
                 ? array_map(static fn (Campaign $c) => $c->toArray(), $this->campaignsReceived)
                 : null,
-            'canvases_received' => $this->canvasesReceived !== null
+            self::FIELD_CANVASES_RECEIVED => $this->canvasesReceived !== null
                 ? array_map(static fn (Canvas $c) => $c->toArray(), $this->canvasesReceived)
                 : null,
-            'cards_clicked' => $this->cardsClicked !== null
+            self::FIELD_CARDS_CLICKED => $this->cardsClicked !== null
                 ? array_map(static fn (Card $c) => $c->toArray(), $this->cardsClicked)
                 : null,
         ], static fn ($value) => $value !== null);

--- a/src/Api/Response/ApiUserExportResponse.php
+++ b/src/Api/Response/ApiUserExportResponse.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Lingoda\BrazeBundle\Api\Response;
 
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\User;
+
 class ApiUserExportResponse extends ApiResponse
 {
     /**
@@ -21,9 +23,17 @@ class ApiUserExportResponse extends ApiResponse
     }
 
     /**
-     * @return mixed[]
+     * @return User[]
      */
     public function getUsers(): array
+    {
+        return array_map(User::fromArray(...), $this->users);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getUsersRaw(): array
     {
         return $this->users;
     }

--- a/tests/Api/Object/Export/UserData/AppTest.php
+++ b/tests/Api/Object/Export/UserData/AppTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\App;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\App
+ */
+final class AppTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        // Setup
+        $data = [
+            'name' => 'MovieCannon',
+            'platform' => 'Android',
+            'version' => '3.29.0',
+            'sessions' => 1129,
+            'first_used' => '2020-02-02T19:56:19.142Z',
+            'last_used' => '2021-11-11T00:25:19.201Z',
+        ];
+
+        // Execution
+        $app = App::fromArray($data);
+        $result = $app->toArray();
+
+        // Assertion
+        self::assertSame('MovieCannon', $app->name);
+        self::assertSame('Android', $app->platform);
+        self::assertSame('3.29.0', $app->version);
+        self::assertSame(1129, $app->sessions);
+        self::assertSame('2020-02-02', $app->firstUsed->format('Y-m-d'));
+        self::assertSame('2021-11-11', $app->lastUsed->format('Y-m-d'));
+        self::assertSame('2020-02-02T19:56:19.142+00:00', $result['first_used']);
+        self::assertSame('2021-11-11T00:25:19.201+00:00', $result['last_used']);
+    }
+
+    /**
+     * @return iterable<string, array{data: array<string, mixed>, expectedMessage: string}>
+     */
+    public static function provideTestFromArrayThrowsExceptionForInvalidDateData(): iterable
+    {
+        yield 'invalid first_used' => [
+            'data' => [
+                'name' => 'MovieCannon',
+                'platform' => 'Android',
+                'version' => '3.29.0',
+                'sessions' => 1129,
+                'first_used' => 'invalid-date',
+                'last_used' => '2021-11-11T00:25:19.201Z',
+            ],
+            'expectedMessage' => 'Invalid date format for first_used',
+        ];
+
+        yield 'invalid last_used' => [
+            'data' => [
+                'name' => 'MovieCannon',
+                'platform' => 'Android',
+                'version' => '3.29.0',
+                'sessions' => 1129,
+                'first_used' => '2020-02-02T19:56:19.142Z',
+                'last_used' => 'invalid-date',
+            ],
+            'expectedMessage' => 'Invalid date format for last_used',
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayThrowsExceptionForInvalidDateData
+     *
+     * @param array<string, mixed> $data
+     */
+    public function testFromArrayThrowsExceptionForInvalidDate(array $data, string $expectedMessage): void
+    {
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Execution
+        App::fromArray($data);
+    }
+}

--- a/tests/Api/Object/Export/UserData/CampaignEngagementTest.php
+++ b/tests/Api/Object/Export/UserData/CampaignEngagementTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\CampaignEngagement;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\CampaignEngagement
+ */
+final class CampaignEngagementTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{
+     *     input: array<string, bool>,
+     *     expectedProperties: array<string, bool|null>,
+     *     expectedOutput: array<string, bool>
+     * }>
+     */
+    public static function provideTestFromArrayAndToArrayData(): iterable
+    {
+        yield 'email opened only' => [
+            'input' => ['opened_email' => true],
+            'expectedProperties' => [
+                'openedEmail' => true,
+                'openedPush' => null,
+                'clickedEmail' => null,
+                'clickedTriggeredInAppMessage' => null,
+            ],
+            'expectedOutput' => ['opened_email' => true],
+        ];
+
+        yield 'all engagements set' => [
+            'input' => [
+                'opened_email' => true,
+                'opened_push' => false,
+                'clicked_email' => true,
+                'clicked_triggered_in_app_message' => false,
+            ],
+            'expectedProperties' => [
+                'openedEmail' => true,
+                'openedPush' => false,
+                'clickedEmail' => true,
+                'clickedTriggeredInAppMessage' => false,
+            ],
+            'expectedOutput' => [
+                'opened_email' => true,
+                'opened_push' => false,
+                'clicked_email' => true,
+                'clicked_triggered_in_app_message' => false,
+            ],
+        ];
+
+        yield 'empty engagement' => [
+            'input' => [],
+            'expectedProperties' => [
+                'openedEmail' => null,
+                'openedPush' => null,
+                'clickedEmail' => null,
+                'clickedTriggeredInAppMessage' => null,
+            ],
+            'expectedOutput' => [],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayAndToArrayData
+     *
+     * @param array<string, bool> $input
+     * @param array<string, bool|null> $expectedProperties
+     * @param array<string, bool> $expectedOutput
+     */
+    public function testFromArrayAndToArray(
+        array $input,
+        array $expectedProperties,
+        array $expectedOutput,
+    ): void {
+        // Execution
+        $engagement = CampaignEngagement::fromArray($input);
+        $result = $engagement->toArray();
+
+        // Assertion
+        self::assertSame($expectedProperties['openedEmail'], $engagement->openedEmail);
+        self::assertSame($expectedProperties['openedPush'], $engagement->openedPush);
+        self::assertSame($expectedProperties['clickedEmail'], $engagement->clickedEmail);
+        self::assertSame($expectedProperties['clickedTriggeredInAppMessage'], $engagement->clickedTriggeredInAppMessage);
+        self::assertSame($expectedOutput, $result);
+    }
+}

--- a/tests/Api/Object/Export/UserData/CampaignTest.php
+++ b/tests/Api/Object/Export/UserData/CampaignTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Campaign;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\Campaign
+ */
+final class CampaignTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{
+     *     input: array<string, mixed>,
+     *     expectedOptionalFields: array<string, mixed>
+     * }>
+     */
+    public static function provideTestFromArrayAndToArrayData(): iterable
+    {
+        yield 'full API response' => [
+            'input' => [
+                'name' => 'Email Unsubscribe',
+                'api_campaign_id' => 'd72fdc84-ddda-44f1-a0d5-0e79f47ef942',
+                'last_received' => '2022-06-02T03:07:38.105Z',
+                'engaged' => ['opened_email' => true],
+                'converted' => true,
+                'in_control' => false,
+                'variation_name' => 'Variant 1',
+                'variation_api_id' => '1bddc73a-a134-4784-9134-5b5574a9e0b8',
+            ],
+            'expectedOptionalFields' => [
+                'variationName' => 'Variant 1',
+                'variationApiId' => '1bddc73a-a134-4784-9134-5b5574a9e0b8',
+                'multipleConverted' => null,
+            ],
+        ];
+
+        yield 'required fields only' => [
+            'input' => [
+                'name' => 'Email Unsubscribe',
+                'api_campaign_id' => 'd72fdc84-ddda-44f1-a0d5-0e79f47ef942',
+                'last_received' => '2022-06-02T03:07:38.105Z',
+                'engaged' => [],
+                'converted' => false,
+                'in_control' => true,
+            ],
+            'expectedOptionalFields' => [
+                'variationName' => null,
+                'variationApiId' => null,
+                'multipleConverted' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayAndToArrayData
+     *
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $expectedOptionalFields
+     */
+    public function testFromArrayAndToArray(array $input, array $expectedOptionalFields): void
+    {
+        // Execution
+        $campaign = Campaign::fromArray($input);
+        $result = $campaign->toArray();
+
+        // Assertion
+        self::assertSame($input['name'], $campaign->name);
+        self::assertSame($input['api_campaign_id'], $campaign->apiCampaignId);
+        self::assertSame('2022-06-02', $campaign->lastReceived->format('Y-m-d'));
+        self::assertSame($input['converted'], $campaign->converted);
+        self::assertSame($input['in_control'], $campaign->inControl);
+        self::assertSame($expectedOptionalFields['variationName'], $campaign->variationName);
+        self::assertSame($expectedOptionalFields['variationApiId'], $campaign->variationApiId);
+        self::assertSame($expectedOptionalFields['multipleConverted'], $campaign->multipleConverted);
+        self::assertSame('2022-06-02T03:07:38.105+00:00', $result['last_received']);
+    }
+
+    public function testFromArrayThrowsExceptionForInvalidLastReceivedDate(): void
+    {
+        // Setup
+        $data = [
+            'name' => 'Email Unsubscribe',
+            'api_campaign_id' => 'd72fdc84-ddda-44f1-a0d5-0e79f47ef942',
+            'last_received' => 'invalid-date',
+            'engaged' => [],
+            'converted' => true,
+            'in_control' => false,
+        ];
+
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid date format for last_received');
+
+        // Execution
+        Campaign::fromArray($data);
+    }
+}

--- a/tests/Api/Object/Export/UserData/CanvasStepTest.php
+++ b/tests/Api/Object/Export/UserData/CanvasStepTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\CanvasStep;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\CanvasStep
+ */
+final class CanvasStepTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        // Setup
+        $data = [
+            'name' => 'Step',
+            'api_canvas_step_id' => '43d1a349-c3c8-4be1-9fbe-ce708e4d1c39',
+            'last_received' => '2021-07-07T20:46:24.136Z',
+        ];
+
+        // Execution
+        $step = CanvasStep::fromArray($data);
+        $result = $step->toArray();
+
+        // Assertion
+        self::assertSame('Step', $step->name);
+        self::assertSame('43d1a349-c3c8-4be1-9fbe-ce708e4d1c39', $step->apiCanvasStepId);
+        self::assertSame('2021-07-07', $step->lastReceived->format('Y-m-d'));
+        self::assertSame('2021-07-07T20:46:24.136+00:00', $result['last_received']);
+    }
+
+    public function testFromArrayThrowsExceptionForInvalidLastReceivedDate(): void
+    {
+        // Setup
+        $data = [
+            'name' => 'Step',
+            'api_canvas_step_id' => '43d1a349-c3c8-4be1-9fbe-ce708e4d1c39',
+            'last_received' => 'invalid-date',
+        ];
+
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid date format for last_received');
+
+        // Execution
+        CanvasStep::fromArray($data);
+    }
+}

--- a/tests/Api/Object/Export/UserData/CanvasTest.php
+++ b/tests/Api/Object/Export/UserData/CanvasTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Canvas;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\Canvas
+ */
+final class CanvasTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{
+     *     input: array<string, mixed>,
+     *     expectedStepsCount: int|null
+     * }>
+     */
+    public static function provideTestFromArrayAndToArrayData(): iterable
+    {
+        yield 'full API response with steps' => [
+            'input' => [
+                'name' => 'Non Global Holdout Group 4/21/21',
+                'api_canvas_id' => '46972a9d-dc81-473f-aa03-e3473b4ed781',
+                'last_received_message' => '2021-07-07T20:46:24.136Z',
+                'last_entered' => '2021-07-07T20:45:24.000+00:00',
+                'variation_name' => 'Variant 1',
+                'in_control' => false,
+                'last_exited' => '2021-07-07T20:46:24.136Z',
+                'steps_received' => [
+                    [
+                        'name' => 'Step',
+                        'api_canvas_step_id' => '43d1a349-c3c8-4be1-9fbe-ce708e4d1c39',
+                        'last_received' => '2021-07-07T20:46:24.136Z',
+                    ],
+                ],
+            ],
+            'expectedStepsCount' => 1,
+        ];
+
+        yield 'required fields only' => [
+            'input' => [
+                'name' => 'Canvas Name',
+                'api_canvas_id' => '46972a9d-dc81-473f-aa03-e3473b4ed781',
+                'last_received_message' => '2021-07-07T20:46:24.136Z',
+                'last_entered' => '2021-07-07T20:45:24.000+00:00',
+                'last_exited' => '2021-07-07T20:46:24.136Z',
+                'in_control' => true,
+            ],
+            'expectedStepsCount' => null,
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayAndToArrayData
+     *
+     * @param array<string, mixed> $input
+     */
+    public function testFromArrayAndToArray(array $input, ?int $expectedStepsCount): void
+    {
+        // Execution
+        $canvas = Canvas::fromArray($input);
+        $result = $canvas->toArray();
+
+        // Assertion
+        self::assertSame($input['name'], $canvas->name);
+        self::assertSame($input['api_canvas_id'], $canvas->apiCanvasId);
+        self::assertSame('2021-07-07', $canvas->lastReceivedMessage->format('Y-m-d'));
+        self::assertSame('2021-07-07', $canvas->lastEntered->format('Y-m-d'));
+        self::assertSame('2021-07-07', $canvas->lastExited->format('Y-m-d'));
+        self::assertSame($input['in_control'], $canvas->inControl);
+        self::assertSame($input['variation_name'] ?? null, $canvas->variationName);
+
+        if ($expectedStepsCount !== null) {
+            self::assertNotNull($canvas->stepsReceived);
+            self::assertCount($expectedStepsCount, $canvas->stepsReceived);
+            self::assertIsArray($result['steps_received']);
+            self::assertCount($expectedStepsCount, $result['steps_received']);
+        } else {
+            self::assertNull($canvas->stepsReceived);
+            self::assertArrayNotHasKey('steps_received', $result);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{data: array<string, mixed>, expectedMessage: string}>
+     */
+    public static function provideTestFromArrayThrowsExceptionForInvalidDateData(): iterable
+    {
+        yield 'invalid last_received_message' => [
+            'data' => [
+                'name' => 'Canvas Name',
+                'api_canvas_id' => '46972a9d-dc81-473f-aa03-e3473b4ed781',
+                'last_received_message' => 'invalid-date',
+                'last_entered' => '2021-07-07T20:45:24.000+00:00',
+                'last_exited' => '2021-07-07T20:46:24.136Z',
+                'in_control' => true,
+            ],
+            'expectedMessage' => 'Invalid date format for last_received_message',
+        ];
+
+        yield 'invalid last_entered' => [
+            'data' => [
+                'name' => 'Canvas Name',
+                'api_canvas_id' => '46972a9d-dc81-473f-aa03-e3473b4ed781',
+                'last_received_message' => '2021-07-07T20:46:24.136Z',
+                'last_entered' => 'invalid-date',
+                'last_exited' => '2021-07-07T20:46:24.136Z',
+                'in_control' => true,
+            ],
+            'expectedMessage' => 'Invalid date format for last_entered',
+        ];
+
+        yield 'invalid last_exited' => [
+            'data' => [
+                'name' => 'Canvas Name',
+                'api_canvas_id' => '46972a9d-dc81-473f-aa03-e3473b4ed781',
+                'last_received_message' => '2021-07-07T20:46:24.136Z',
+                'last_entered' => '2021-07-07T20:45:24.000+00:00',
+                'last_exited' => 'invalid-date',
+                'in_control' => true,
+            ],
+            'expectedMessage' => 'Invalid date format for last_exited',
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayThrowsExceptionForInvalidDateData
+     *
+     * @param array<string, mixed> $data
+     */
+    public function testFromArrayThrowsExceptionForInvalidDate(array $data, string $expectedMessage): void
+    {
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Execution
+        Canvas::fromArray($data);
+    }
+}

--- a/tests/Api/Object/Export/UserData/CardTest.php
+++ b/tests/Api/Object/Export/UserData/CardTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Card;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\Card
+ */
+final class CardTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        // Setup
+        $data = ['name' => 'Loyalty Promo'];
+
+        // Execution
+        $card = Card::fromArray($data);
+        $result = $card->toArray();
+
+        // Assertion
+        self::assertSame('Loyalty Promo', $card->name);
+        self::assertSame($data, $result);
+    }
+}

--- a/tests/Api/Object/Export/UserData/CustomEventTest.php
+++ b/tests/Api/Object/Export/UserData/CustomEventTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\CustomEvent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\CustomEvent
+ */
+final class CustomEventTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        // Setup
+        $data = [
+            'name' => 'Loyalty Acknowledgement',
+            'first' => '2021-06-28T17:02:43.032Z',
+            'last' => '2021-06-28T17:02:43.032Z',
+            'count' => 1,
+        ];
+
+        // Execution
+        $event = CustomEvent::fromArray($data);
+        $result = $event->toArray();
+
+        // Assertion
+        self::assertSame('Loyalty Acknowledgement', $event->name);
+        self::assertSame('2021-06-28', $event->first->format('Y-m-d'));
+        self::assertSame('2021-06-28', $event->last->format('Y-m-d'));
+        self::assertSame(1, $event->count);
+        self::assertSame('2021-06-28T17:02:43.032+00:00', $result['first']);
+        self::assertSame('2021-06-28T17:02:43.032+00:00', $result['last']);
+    }
+
+    /**
+     * @return iterable<string, array{data: array<string, mixed>, expectedMessage: string}>
+     */
+    public static function provideTestFromArrayThrowsExceptionForInvalidDateData(): iterable
+    {
+        yield 'invalid first' => [
+            'data' => [
+                'name' => 'Loyalty Acknowledgement',
+                'first' => 'invalid-date',
+                'last' => '2021-06-28T17:02:43.032Z',
+                'count' => 1,
+            ],
+            'expectedMessage' => 'Invalid date format for first',
+        ];
+
+        yield 'invalid last' => [
+            'data' => [
+                'name' => 'Loyalty Acknowledgement',
+                'first' => '2021-06-28T17:02:43.032Z',
+                'last' => 'invalid-date',
+                'count' => 1,
+            ],
+            'expectedMessage' => 'Invalid date format for last',
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayThrowsExceptionForInvalidDateData
+     *
+     * @param array<string, mixed> $data
+     */
+    public function testFromArrayThrowsExceptionForInvalidDate(array $data, string $expectedMessage): void
+    {
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Execution
+        CustomEvent::fromArray($data);
+    }
+}

--- a/tests/Api/Object/Export/UserData/DeviceTest.php
+++ b/tests/Api/Object/Export/UserData/DeviceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Device;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\Device
+ */
+final class DeviceTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{
+     *     input: array<string, mixed>,
+     *     expectedOutput: array<string, mixed>
+     * }>
+     */
+    public static function provideTestFromArrayAndToArrayData(): iterable
+    {
+        yield 'required fields only' => [
+            'input' => [
+                'model' => 'Pixel XL',
+                'os' => 'Android (Q)',
+                'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+                'ad_tracking_enabled' => true,
+            ],
+            'expectedOutput' => [
+                'model' => 'Pixel XL',
+                'os' => 'Android (Q)',
+                'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+                'ad_tracking_enabled' => true,
+            ],
+        ];
+
+        yield 'all fields set' => [
+            'input' => [
+                'model' => 'iPhone 14',
+                'os' => 'iOS 16.0',
+                'device_id' => 'abc123',
+                'ad_tracking_enabled' => false,
+                'carrier' => 'Verizon',
+                'idfv' => 'idfv-123',
+                'idfa' => 'idfa-456',
+                'google_ad_id' => 'google-789',
+                'roku_ad_id' => 'roku-012',
+            ],
+            'expectedOutput' => [
+                'model' => 'iPhone 14',
+                'os' => 'iOS 16.0',
+                'device_id' => 'abc123',
+                'ad_tracking_enabled' => false,
+                'carrier' => 'Verizon',
+                'idfv' => 'idfv-123',
+                'idfa' => 'idfa-456',
+                'google_ad_id' => 'google-789',
+                'roku_ad_id' => 'roku-012',
+            ],
+        ];
+
+        yield 'explicit null carrier from API' => [
+            'input' => [
+                'model' => 'Pixel XL',
+                'os' => 'Android (Q)',
+                'carrier' => null,
+                'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+                'ad_tracking_enabled' => true,
+            ],
+            'expectedOutput' => [
+                'model' => 'Pixel XL',
+                'os' => 'Android (Q)',
+                'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+                'ad_tracking_enabled' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayAndToArrayData
+     *
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $expectedOutput
+     */
+    public function testFromArrayAndToArray(array $input, array $expectedOutput): void
+    {
+        // Execution
+        $device = Device::fromArray($input);
+        $result = $device->toArray();
+
+        // Assertion
+        self::assertSame($input['model'], $device->model);
+        self::assertSame($input['os'], $device->os);
+        self::assertSame($input['device_id'], $device->deviceId);
+        self::assertSame($input['ad_tracking_enabled'], $device->adTrackingEnabled);
+        self::assertSame($expectedOutput, $result);
+    }
+}

--- a/tests/Api/Object/Export/UserData/GenderTest.php
+++ b/tests/Api/Object/Export/UserData/GenderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Gender;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\Gender
+ */
+final class GenderTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{value: string, expected: Gender}>
+     */
+    public static function provideTestFromValidApiValueData(): iterable
+    {
+        yield 'male' => ['value' => 'M', 'expected' => Gender::Male];
+        yield 'female' => ['value' => 'F', 'expected' => Gender::Female];
+        yield 'other' => ['value' => 'O', 'expected' => Gender::Other];
+        yield 'not applicable' => ['value' => 'N', 'expected' => Gender::NotApplicable];
+        yield 'prefer not to say' => ['value' => 'P', 'expected' => Gender::PreferNotToSay];
+        yield 'unknown (nil)' => ['value' => 'nil', 'expected' => Gender::Unknown];
+    }
+
+    /**
+     * @dataProvider provideTestFromValidApiValueData
+     *
+     * @throws \TypeError
+     * @throws \ValueError
+     */
+    public function testFromValidApiValue(string $value, Gender $expected): void
+    {
+        // Execution
+        $gender = Gender::from($value);
+
+        // Assertion
+        self::assertSame($expected, $gender);
+        self::assertSame($value, $gender->value);
+    }
+
+    public function testTryFromReturnsNullForInvalidValue(): void
+    {
+        // Execution & Assertion
+        self::assertNull(Gender::tryFrom('invalid'));
+    }
+}

--- a/tests/Api/Object/Export/UserData/PurchaseTest.php
+++ b/tests/Api/Object/Export/UserData/PurchaseTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Purchase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\Purchase
+ */
+final class PurchaseTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        // Setup
+        $data = [
+            'name' => 'item_40834',
+            'first' => '2021-09-05T03:45:50.540Z',
+            'last' => '2022-06-03T17:30:41.201Z',
+            'count' => 10,
+        ];
+
+        // Execution
+        $purchase = Purchase::fromArray($data);
+        $result = $purchase->toArray();
+
+        // Assertion
+        self::assertSame('item_40834', $purchase->name);
+        self::assertSame('2021-09-05', $purchase->first->format('Y-m-d'));
+        self::assertSame('2022-06-03', $purchase->last->format('Y-m-d'));
+        self::assertSame(10, $purchase->count);
+        self::assertSame('2021-09-05T03:45:50.540+00:00', $result['first']);
+        self::assertSame('2022-06-03T17:30:41.201+00:00', $result['last']);
+    }
+
+    /**
+     * @return iterable<string, array{data: array<string, mixed>, expectedMessage: string}>
+     */
+    public static function provideTestFromArrayThrowsExceptionForInvalidDateData(): iterable
+    {
+        yield 'invalid first' => [
+            'data' => [
+                'name' => 'item_40834',
+                'first' => 'invalid-date',
+                'last' => '2022-06-03T17:30:41.201Z',
+                'count' => 10,
+            ],
+            'expectedMessage' => 'Invalid date format for first',
+        ];
+
+        yield 'invalid last' => [
+            'data' => [
+                'name' => 'item_40834',
+                'first' => '2021-09-05T03:45:50.540Z',
+                'last' => 'invalid-date',
+                'count' => 10,
+            ],
+            'expectedMessage' => 'Invalid date format for last',
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayThrowsExceptionForInvalidDateData
+     *
+     * @param array<string, mixed> $data
+     */
+    public function testFromArrayThrowsExceptionForInvalidDate(array $data, string $expectedMessage): void
+    {
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Execution
+        Purchase::fromArray($data);
+    }
+}

--- a/tests/Api/Object/Export/UserData/PushTokenTest.php
+++ b/tests/Api/Object/Export/UserData/PushTokenTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\PushToken;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\PushToken
+ */
+final class PushTokenTest extends TestCase
+{
+    public function testFromArrayAndToArrayRoundTrip(): void
+    {
+        // Setup
+        $data = [
+            'app' => 'MovieCanon',
+            'platform' => 'Android',
+            'token' => '12345abcd',
+            'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+            'notifications_enabled' => true,
+        ];
+
+        // Execution
+        $pushToken = PushToken::fromArray($data);
+        $result = $pushToken->toArray();
+
+        // Assertion
+        self::assertSame('MovieCanon', $pushToken->app);
+        self::assertSame('Android', $pushToken->platform);
+        self::assertSame('12345abcd', $pushToken->token);
+        self::assertSame('312ef2c1-83db-4789-967-554545a1bf7a', $pushToken->deviceId);
+        self::assertTrue($pushToken->notificationsEnabled);
+        self::assertSame($data, $result);
+    }
+}

--- a/tests/Api/Object/Export/UserData/UserTest.php
+++ b/tests/Api/Object/Export/UserData/UserTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\BrazeBundle\Tests\Api\Object\Export\UserData;
+
+use DateTimeImmutable;
+use Lingoda\BrazeBundle\Api\Exception\InvalidArgumentException;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\App;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Campaign;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Canvas;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Card;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\CustomEvent;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Device;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Gender;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\Purchase;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\PushToken;
+use Lingoda\BrazeBundle\Api\Object\Export\UserData\User;
+use Lingoda\BrazeBundle\Api\Object\UserAlias;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lingoda\BrazeBundle\Api\Object\Export\UserData\User
+ */
+final class UserTest extends TestCase
+{
+    public function testFromArrayCreatesUserFromFullApiResponse(): void
+    {
+        // Setup
+        $data = $this->getFullApiResponseData();
+
+        // Execution
+        $user = User::fromArray($data);
+
+        // Assertion - basic fields
+        self::assertNotNull($user->createdAt);
+        self::assertSame('2020-07-10', $user->createdAt->format('Y-m-d'));
+        self::assertSame('A8i3mkd99', $user->externalId);
+        self::assertSame('5fbd99bac125ca40511f2cb1', $user->brazeId);
+        self::assertSame(2365, $user->randomBucket);
+        self::assertSame('Jane', $user->firstName);
+        self::assertSame('Doe', $user->lastName);
+        self::assertSame('[email protected]', $user->email);
+        self::assertNotNull($user->dob);
+        self::assertSame('1980-12-21', $user->dob->format('Y-m-d'));
+        self::assertSame('Chicago', $user->homeCity);
+        self::assertSame('US', $user->country);
+        self::assertSame('+442071838750', $user->phone);
+        self::assertSame('en', $user->language);
+        self::assertSame('Eastern Time (US & Canada)', $user->timeZone);
+        self::assertSame(Gender::Female, $user->gender);
+        self::assertSame([41.84157636433568, -87.83520818508256], $user->lastCoordinates);
+        self::assertSame('opted_in', $user->pushSubscribe);
+        self::assertNotNull($user->pushOptedInAt);
+        self::assertSame('2020-01-26', $user->pushOptedInAt->format('Y-m-d'));
+        self::assertSame('subscribed', $user->emailSubscribe);
+        self::assertSame(65.0, $user->totalRevenue);
+
+        // Assertion - nested objects
+        self::assertNotNull($user->userAliases);
+        self::assertCount(1, $user->userAliases);
+        self::assertInstanceOf(UserAlias::class, $user->userAliases[0]);
+        self::assertNotNull($user->customEvents);
+        self::assertCount(1, $user->customEvents);
+        self::assertInstanceOf(CustomEvent::class, $user->customEvents[0]);
+        self::assertNotNull($user->purchases);
+        self::assertCount(1, $user->purchases);
+        self::assertInstanceOf(Purchase::class, $user->purchases[0]);
+        self::assertNotNull($user->devices);
+        self::assertCount(1, $user->devices);
+        self::assertInstanceOf(Device::class, $user->devices[0]);
+        self::assertNotNull($user->pushTokens);
+        self::assertCount(1, $user->pushTokens);
+        self::assertInstanceOf(PushToken::class, $user->pushTokens[0]);
+        self::assertNotNull($user->apps);
+        self::assertCount(1, $user->apps);
+        self::assertInstanceOf(App::class, $user->apps[0]);
+        self::assertNotNull($user->campaignsReceived);
+        self::assertCount(1, $user->campaignsReceived);
+        self::assertInstanceOf(Campaign::class, $user->campaignsReceived[0]);
+        self::assertNotNull($user->canvasesReceived);
+        self::assertCount(1, $user->canvasesReceived);
+        self::assertInstanceOf(Canvas::class, $user->canvasesReceived[0]);
+        self::assertNotNull($user->cardsClicked);
+        self::assertCount(1, $user->cardsClicked);
+        self::assertInstanceOf(Card::class, $user->cardsClicked[0]);
+    }
+
+    public function testFromArrayCreatesUserWithMinimalData(): void
+    {
+        // Setup
+        $data = ['external_id' => 'user-123'];
+
+        // Execution
+        $user = User::fromArray($data);
+
+        // Assertion
+        self::assertSame('user-123', $user->externalId);
+        self::assertNull($user->createdAt);
+        self::assertNull($user->brazeId);
+        self::assertNull($user->userAliases);
+        self::assertNull($user->customEvents);
+        self::assertNull($user->purchases);
+        self::assertNull($user->devices);
+    }
+
+    public function testFromArrayHandlesUnknownGenderGracefully(): void
+    {
+        // Setup
+        $data = ['external_id' => 'user-123', 'gender' => 'unknown_value'];
+
+        // Execution
+        $user = User::fromArray($data);
+
+        // Assertion
+        self::assertNull($user->gender);
+    }
+
+    public function testToArrayReturnsApiCompatibleFormat(): void
+    {
+        // Setup
+        $createdAt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.v e', '2020-07-10 15:00:00.000 UTC');
+        $dob = DateTimeImmutable::createFromFormat('Y-m-d', '1980-12-21');
+        self::assertInstanceOf(DateTimeImmutable::class, $createdAt);
+        self::assertInstanceOf(DateTimeImmutable::class, $dob);
+
+        $user = new User(
+            createdAt: $createdAt,
+            externalId: 'A8i3mkd99',
+            brazeId: '5fbd99bac125ca40511f2cb1',
+            userAliases: [new UserAlias('user_123', 'amplitude_id')],
+            firstName: 'Jane',
+            lastName: 'Doe',
+            dob: $dob,
+            gender: Gender::Female,
+            cardsClicked: [new Card(name: 'Loyalty Promo')],
+        );
+
+        // Execution
+        $result = $user->toArray();
+
+        // Assertion
+        self::assertSame('2020-07-10 15:00:00.000 UTC', $result['created_at']);
+        self::assertSame('A8i3mkd99', $result['external_id']);
+        self::assertSame('5fbd99bac125ca40511f2cb1', $result['braze_id']);
+        self::assertSame([['alias_name' => 'user_123', 'alias_label' => 'amplitude_id']], $result['user_aliases']);
+        self::assertSame('Jane', $result['first_name']);
+        self::assertSame('Doe', $result['last_name']);
+        self::assertSame('1980-12-21', $result['dob']);
+        self::assertSame('F', $result['gender']);
+        self::assertSame([['name' => 'Loyalty Promo']], $result['cards_clicked']);
+    }
+
+    public function testToArrayFiltersNullValues(): void
+    {
+        // Setup
+        $user = new User(externalId: 'user-123');
+
+        // Execution
+        $result = $user->toArray();
+
+        // Assertion
+        self::assertSame(['external_id' => 'user-123'], $result);
+    }
+
+    /**
+     * @return iterable<string, array{data: array<string, mixed>, expectedMessage: string}>
+     */
+    public static function provideTestFromArrayThrowsExceptionForInvalidDateData(): iterable
+    {
+        yield 'invalid created_at' => [
+            'data' => ['external_id' => 'user-123', 'created_at' => 'invalid-date'],
+            'expectedMessage' => 'Invalid date format for created_at',
+        ];
+
+        yield 'invalid dob' => [
+            'data' => ['external_id' => 'user-123', 'dob' => 'invalid-date'],
+            'expectedMessage' => 'Invalid date format for dob',
+        ];
+
+        yield 'invalid push_opted_in_at' => [
+            'data' => ['external_id' => 'user-123', 'push_opted_in_at' => 'invalid-date'],
+            'expectedMessage' => 'Invalid date format for push_opted_in_at',
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestFromArrayThrowsExceptionForInvalidDateData
+     *
+     * @param array<string, mixed> $data
+     */
+    public function testFromArrayThrowsExceptionForInvalidDate(array $data, string $expectedMessage): void
+    {
+        // Expect
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Execution
+        User::fromArray($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getFullApiResponseData(): array
+    {
+        return [
+            'created_at' => '2020-07-10 15:00:00.000 UTC',
+            'external_id' => 'A8i3mkd99',
+            'user_aliases' => [['alias_name' => 'user_123', 'alias_label' => 'amplitude_id']],
+            'braze_id' => '5fbd99bac125ca40511f2cb1',
+            'random_bucket' => 2365,
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+            'email' => '[email protected]',
+            'dob' => '1980-12-21',
+            'home_city' => 'Chicago',
+            'country' => 'US',
+            'phone' => '+442071838750',
+            'language' => 'en',
+            'time_zone' => 'Eastern Time (US & Canada)',
+            'last_coordinates' => [41.84157636433568, -87.83520818508256],
+            'gender' => 'F',
+            'total_revenue' => 65.0,
+            'attributed_campaign' => 'braze_test_campaign_072219',
+            'attributed_source' => 'braze_test_source_072219',
+            'attributed_adgroup' => 'braze_test_adgroup_072219',
+            'attributed_ad' => 'braze_test_ad_072219',
+            'push_subscribe' => 'opted_in',
+            'push_opted_in_at' => '2020-01-26T22:45:53.953Z',
+            'email_subscribe' => 'subscribed',
+            'custom_attributes' => [
+                'loyaltyId' => '37c98b9d-9a7f-4b2f-a125-d873c5152856',
+                'loyaltyPoints' => '321',
+                'loyaltyPointsNumber' => 107,
+            ],
+            'custom_events' => [[
+                'name' => 'Loyalty Acknowledgement',
+                'first' => '2021-06-28T17:02:43.032Z',
+                'last' => '2021-06-28T17:02:43.032Z',
+                'count' => 1,
+            ]],
+            'purchases' => [[
+                'name' => 'item_40834',
+                'first' => '2021-09-05T03:45:50.540Z',
+                'last' => '2022-06-03T17:30:41.201Z',
+                'count' => 10,
+            ]],
+            'devices' => [[
+                'model' => 'Pixel XL',
+                'os' => 'Android (Q)',
+                'carrier' => null,
+                'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+                'ad_tracking_enabled' => true,
+            ]],
+            'push_tokens' => [[
+                'app' => 'MovieCanon',
+                'platform' => 'Android',
+                'token' => '12345abcd',
+                'device_id' => '312ef2c1-83db-4789-967-554545a1bf7a',
+                'notifications_enabled' => true,
+            ]],
+            'apps' => [[
+                'name' => 'MovieCannon',
+                'platform' => 'Android',
+                'version' => '3.29.0',
+                'sessions' => 1129,
+                'first_used' => '2020-02-02T19:56:19.142Z',
+                'last_used' => '2021-11-11T00:25:19.201Z',
+            ]],
+            'campaigns_received' => [[
+                'name' => 'Email Unsubscribe',
+                'api_campaign_id' => 'd72fdc84-ddda-44f1-a0d5-0e79f47ef942',
+                'last_received' => '2022-06-02T03:07:38.105Z',
+                'engaged' => ['opened_email' => true],
+                'converted' => true,
+                'in_control' => false,
+                'variation_name' => 'Variant 1',
+                'variation_api_id' => '1bddc73a-a134-4784-9134-5b5574a9e0b8',
+            ]],
+            'canvases_received' => [[
+                'name' => 'Non Global Holdout Group 4/21/21',
+                'api_canvas_id' => '46972a9d-dc81-473f-aa03-e3473b4ed781',
+                'last_received_message' => '2021-07-07T20:46:24.136Z',
+                'last_entered' => '2021-07-07T20:45:24.000+00:00',
+                'variation_name' => 'Variant 1',
+                'in_control' => false,
+                'last_exited' => '2021-07-07T20:46:24.136Z',
+                'steps_received' => [[
+                    'name' => 'Step',
+                    'api_canvas_step_id' => '43d1a349-c3c8-4be1-9fbe-ce708e4d1c39',
+                    'last_received' => '2021-07-07T20:46:24.136Z',
+                ]],
+            ]],
+            'cards_clicked' => [['name' => 'Loyalty Promo']],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request introduces a new set of strongly-typed value objects for user export data in the Braze integration, providing a robust and consistent way to represent and serialize user-related export entities. It adds a shared `SerializableExportObject` interface and implements it across multiple new classes, each encapsulating a specific aspect of user data (such as apps, campaigns, devices, events, purchases, etc.). The changes also update the test specification to use these new objects for improved test accuracy and maintainability.

**Introduction of value objects for user export data:**

* Added the `SerializableExportObject` interface in `src/Api/Object/Export/SerializableExportObject.php`, defining `fromArray` and `toArray` methods for consistent serialization and deserialization of export objects.
* Implemented new value object classes for various user data entities, each conforming to the new interface:
  - `App`, `Campaign`, `CampaignEngagement`, `Canvas`, `CanvasStep`, `Card`, `CustomEvent`, `Device`, `Gender` (enum), `Purchase`, `PushToken` in the `src/Api/Object/Export/UserData/` directory. These classes provide type safety, proper date parsing, and validation. [[1]](diffhunk://#diff-49470bfdecbb32dff9f4318e8e5d3a2afe1ab1a7f556af0c8dd0cb43da81251bR1-R60) [[2]](diffhunk://#diff-f450c27efe3108b4f16bddd1e51eae3ec231e92912c943aeac00fbb739e9c74aR1-R68) [[3]](diffhunk://#diff-1f595e9574096ec92702a8c037986561cc0ff5cbb46f1d2c2229b66549cc0b32R1-R41) [[4]](diffhunk://#diff-2be0b42e6dcd54d34ec475022112678f02cea92c636719663410582423e5dcffR1-R78) [[5]](diffhunk://#diff-4b8f83628e0c554bd0af90973353b26abeadf1d54c543f332e64f9eaaf008400R1-R50) [[6]](diffhunk://#diff-13c4d44bf262d41e9010f2f7674c5ddde9a6335e40113524cc9b9a8f672aec2eR1-R32) [[7]](diffhunk://#diff-d646c12b2b78d1e019da1217b463feb6eb73bb63c87a41d4b8e963d4de734b7bR1-R54) [[8]](diffhunk://#diff-04c6d9ed1d93d3a1aa34024e8ed38999f55efc6b90a29ab7041f2c04508bf987R1-R56) [[9]](diffhunk://#diff-a7ab64745351ab68670eb05a4fa170de40011b59234cddb68d376b3b99ce49e4R1-R15) [[10]](diffhunk://#diff-30658034df124ceb394cb5d69a6d04ea0c2d93bf2c9c4a2fdfb888a24b34fa94R1-R54) [[11]](diffhunk://#diff-9053a37745558a121c4a476c1453f8033de28cbffa53fbe67b28de88decadba7R1-R44)

**Enhancements to testing:**

* Updated the `ApiUserExportResponseSpec.php` test to use the new `User` value object for user data, ensuring the test now verifies both the raw and mapped user representations. [[1]](diffhunk://#diff-4d44cee1c9ec6177054bd8401e0d8e62e1c4a7f256e33084e92473fe444c9518R7) [[2]](diffhunk://#diff-4d44cee1c9ec6177054bd8401e0d8e62e1c4a7f256e33084e92473fe444c9518L22-R24)

These changes lay the groundwork for safer and more maintainable handling of user export data throughout the codebase.